### PR TITLE
Enforce code conventions in ESLint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,6 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "editor.formatOnSave": true,
-  "eslint.rules.customizations": [{ "rule": "*", "severity": "warn" }],
   "eslint.runtime": "node",
   "eslint.workingDirectories": [
     { "pattern": "apps/*/" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -654,6 +654,9 @@ importers:
       '@next/eslint-plugin-next':
         specifier: ^14.2.23
         version: 14.2.23
+      eslint-plugin-filenames-simple:
+        specifier: ^0.9.0
+        version: 0.9.0(eslint@9.19.0(jiti@2.4.2))
       eslint-plugin-import:
         specifier: ^2.31.0
         version: 2.31.0(@typescript-eslint/parser@8.21.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2))
@@ -6736,6 +6739,12 @@ packages:
         optional: true
       eslint-import-resolver-webpack:
         optional: true
+
+  eslint-plugin-filenames-simple@0.9.0:
+    resolution: {integrity: sha512-eIs+fIO/YXjjlNRdMK3H2HiF0BJ6zj3Of1+REBMnHMbqqgxX1VReIV/gf+ZfP3/bbCAHk5PE3SXi7Fjt3uzUGw==}
+    engines: {node: '>=14.17.0'}
+    peerDependencies:
+      eslint: '>=7.0.0 <9.0.0'
 
   eslint-plugin-import@2.31.0:
     resolution: {integrity: sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==}
@@ -20312,6 +20321,11 @@ snapshots:
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
+
+  eslint-plugin-filenames-simple@0.9.0(eslint@9.19.0(jiti@2.4.2)):
+    dependencies:
+      eslint: 9.19.0(jiti@2.4.2)
+      pluralize: 8.0.0
 
   eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.21.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.19.0(jiti@2.4.2)):
     dependencies:

--- a/tooling/eslint/base.js
+++ b/tooling/eslint/base.js
@@ -83,7 +83,18 @@ export default tseslint.config(
           rule: "kebab-case",
         },
       ],
-      "filenames-simple/named-export": ["error", "singular"],
+    },
+  },
+  // apply to all files, but not to pages or layouts
+  // let me know if we need to add more exceptions
+  {
+    files: ["**/*.{ts,tsx}"],
+    ignores: ["**/{page,layout}.tsx"],
+    plugins: {
+      import: importPlugin,
+    },
+    rules: {
+      "import/no-default-export": "warn",
     },
   },
   {

--- a/tooling/eslint/base.js
+++ b/tooling/eslint/base.js
@@ -3,6 +3,7 @@
 import * as path from "node:path";
 import { includeIgnoreFile } from "@eslint/compat";
 import eslint from "@eslint/js";
+import filenamesPlugin from "eslint-plugin-filenames-simple";
 import importPlugin from "eslint-plugin-import";
 import turboPlugin from "eslint-plugin-turbo";
 import tseslint from "typescript-eslint";
@@ -46,6 +47,7 @@ export default tseslint.config(
     plugins: {
       import: importPlugin,
       turbo: turboPlugin,
+      filenames: filenamesPlugin,
     },
     extends: [
       eslint.configs.recommended,
@@ -75,6 +77,13 @@ export default tseslint.config(
       ],
       "@typescript-eslint/no-non-null-assertion": "error",
       "import/consistent-type-specifier-style": ["error", "prefer-top-level"],
+      "filenames/naming-convention": [
+        "warn",
+        {
+          rule: "kebab-case",
+        },
+      ],
+      "filenames-simple/named-export": ["error", "singular"],
     },
   },
   {

--- a/tooling/eslint/package.json
+++ b/tooling/eslint/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@eslint/compat": "^1.2.5",
     "@next/eslint-plugin-next": "^14.2.23",
+    "eslint-plugin-filenames-simple": "^0.9.0",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.4",


### PR DESCRIPTION
Enforces these code conventions in ESLint:
- Prefer kebab-case file names
- Don’t allow default exports (expect when required in next)